### PR TITLE
nix: add nix build and flake support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,179 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "fu": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "ref": "master",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1611672876,
+        "narHash": "sha256-qHu3uZ/o9jBHiA3MEKHJ06k7w4heOhA+4HCSIvflRxo=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "211907489e9f198594c0eb0ca9256a1949c9d412",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
+      },
+      "locked": {
+        "lastModified": 1639398944,
+        "narHash": "sha256-FWwahflfdoEyo/78XaQXJlNyCa2naF/E0V5TRi4xPDo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "807cb8f1feab6aecfd0f6f1b6411aecd47855abc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "master",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1638249621,
+        "narHash": "sha256-5sm83bBBg/U6rALZy/IwITtYY4rJJ5mn4z1Tt5W8FT8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af21d41260846fb9c9840a75e310e56dfe97d6a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1639357775,
+        "narHash": "sha256-mJJFCPqZi1ZO3CvgEfN2nFAYv4uAJSRnTKzLFi61+WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c473cc8714710179df205b153f4e9fa007107ff9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "np": {
+      "locked": {
+        "lastModified": 1639402647,
+        "narHash": "sha256-WmKsV9UW2SxsJtZfQYTFGm9CFvdlHpRyjzjO15z7Svo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3e2ff9dfec5938c02951fe83353806768d7befe4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1624971177,
+        "narHash": "sha256-Amf/nBj1E77RmbSSmV+hg6YOpR+rddCbbVgo5C7BS0I=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "397f0713d007250a2c7a745e555fa16c5dc8cadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fu": "fu",
+        "hls": "hls",
+        "np": "np"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Write your GDB scripts in Haskell";
+  inputs = {
+    np.url = "github:nixos/nixpkgs?ref=master";
+    fu.url = "github:numtide/flake-utils?ref=master";
+    hls.url = "github:haskell/haskell-language-server?ref=master";
+  };
+
+  outputs = { self, np, fu, hls }:
+    with fu.lib;
+    with np.lib;
+    eachSystem [ "x86_64-linux" ] (system:
+      let
+        version =
+          "${substring 0 8 self.lastModifiedDate}.${self.shortRev or "dirty"}";
+        config = { };
+        overlay = final: _:
+          with final;
+          with haskell.lib;
+          with haskellPackages.extend (final: _: { }); {
+            debugger-hs = (callCabal2nix "debugger-hs" ./. { }).overrideAttrs
+              (prev: { version = "${prev.version}.${version}"; });
+          };
+        overlays = [ hls.overlay overlay ];
+      in with (import np { inherit system config overlays; }); rec {
+        inherit overlays;
+        packages = flattenTree (recurseIntoAttrs { inherit debugger-hs; });
+        defaultPackage = packages.debugger-hs;
+        devShell = with haskellPackages;
+          shellFor {
+            packages = _: [ ];
+            buildInputs = [ cabal-install ghc ghcid haskell-language-server ];
+          };
+      });
+}

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,7 @@
+cradle:
+  cabal:
+    - path: "src"
+      component: "lib:debugger-hs"
+
+    - path: "test"
+      component: "debugger-hs:test:debugger-hs-test"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).shellNix


### PR DESCRIPTION
Nix support was added:
```sh
~/P/h/g/debugger-hs (1-add-nix-support) ∫ nix flake show --allow-import-from-derivation 'github:smunix/debugger-hs?ref=1-add-nix-support'
github:smunix/debugger-hs/65e6b6d9d5ed25dd0d8d0b5054b47534afeab593
├───defaultPackage
│   └───x86_64-linux: package 'debugger-hs-0.1.1.0.20211213.65e6b6d'
├───devShell
│   └───x86_64-linux: development environment 'ghc-shell-for-packages-0'
├───overlays
│   └───x86_64-linux: Nixpkgs overlay
└───packages
    └───x86_64-linux
        └───debugger-hs: package 'debugger-hs-0.1.1.0.20211213.65e6b6d'
```

It builds from my repo/branch with
`~ ∫ nix build 'github:smunix/debugger-hs?ref=1-add-nix-support'`